### PR TITLE
Allow `widths` array to have 10 items

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -42,8 +42,8 @@ module.exports = (eleventyConfig, pluginNamespace) => {
                         return typeof w == 'string' ? parseInt(w, 10) : w;
                     });
 
-            if (widths.length && widths.length >= 10) {
-                console.errror("The `widths` array cannot have more than 10 values");
+            if (widths.length && widths.length > 10) {
+                console.error("The `widths` array cannot have more than 10 values");
                 return;
             }
             


### PR DESCRIPTION
Currently the `widths` array only allows 9 items, but the error message says it allows 10